### PR TITLE
allow for ERB in cassy.yml

### DIFF
--- a/lib/cassy/engine.rb
+++ b/lib/cassy/engine.rb
@@ -1,8 +1,9 @@
 module Cassy
   class Engine < Rails::Engine
     config.config_file = ENV["RUBYCAS_CONFIG_FILE"]
-    config.after_initialize do 
-      config.configuration = HashWithIndifferentAccess.new(YAML.load_file(config.config_file))
+    config.after_initialize do
+      file = File.read(config.config_file)
+      config.configuration = HashWithIndifferentAccess.new(YAML.load(ERB.new(file).result))
     end
   end
 end


### PR DESCRIPTION
This allows us to do things like the following in our `cassy.yml`:

```yml
development
- <%= ENV['APP_SERVER_HOST'] || 'http://localhost:3000' %>
```