### PR TITLE
fix fishing attack for unauthorized services

### DIFF
--- a/app/controllers/cassy/sessions_controller.rb
+++ b/app/controllers/cassy/sessions_controller.rb
@@ -5,7 +5,7 @@ module Cassy
 
     def new
       detect_ticketing_service(params[:service])
-      
+
       @renew = params['renew']
       @gateway = params['gateway'] == 'true' || params['gateway'] == '1'
       @hostname = env['HTTP_X_FORWARDED_FOR'] || env['REMOTE_HOST'] || env['REMOTE_ADDR']
@@ -17,7 +17,7 @@ module Cassy
       if params['redirection_loop_intercepted']
         flash.now[:error] = "The client and server are unable to negotiate authentication. Please try logging in again later."
       end
-      
+
       if @service
         if @ticketed_user && cas_login
           redirect_to @service_with_ticket
@@ -36,7 +36,7 @@ module Cassy
 
       @lt = generate_login_ticket.ticket
     end
-    
+
     def create
       @lt = generate_login_ticket.ticket # in case the login isn't successful, another ticket needs to be generated for the next attempt at login
       detect_ticketing_service(params[:service])
@@ -55,12 +55,12 @@ module Cassy
         else
           flash.now[:notice] = "You have successfully logged in."
           render :new
-        end        
+        end
       else
         incorrect_credentials!
       end
     end
-    
+
     def destroy
       # The behaviour here is somewhat non-standard. Rather than showing just a blank
       # "logout" page, we take the user back to the login page with a "you have been logged out"
@@ -74,7 +74,7 @@ module Cassy
       tgt = Cassy::TicketGrantingTicket.find_by_ticket(request.cookies['tgt'])
 
       response.delete_cookie 'tgt'
-      
+
       if tgt
         Cassy::TicketGrantingTicket.transaction do
           stname = ActiveRecord::Base.connection.quote_table_name(Cassy::ServiceTicket.table_name)
@@ -93,7 +93,7 @@ module Cassy
           tgt.destroy
         end
       end
-       
+
       flash[:notice] = "You have successfully logged out."
       @lt = generate_login_ticket
 
@@ -103,10 +103,10 @@ module Cassy
         redirect_to :action => :new, :service => @service
       end
     end
-    
+
     def service_validate
       # takes a params[:service] and a params[:ticket] and validates them
-      
+
       # required
       @service = clean_service_url(params['service'])
       @ticket = params['ticket']
@@ -125,7 +125,7 @@ module Cassy
       end
       render :proxy_validate, :layout => false, :status => @service_ticket ? 200 : 422
     end
-    
+
     def proxy_validate
       # required
       @service = clean_service_url(params['service'])
@@ -154,11 +154,11 @@ module Cassy
       end
 
       render :proxy_validate, :layout => false, :status => @service_ticket ? 200 : 422
-      
+
     end
-    
+
     private
-    
+
     def incorrect_credentials!
       @lt = generate_login_ticket.ticket
       flash.now[:error] = "Incorrect username or password."

--- a/lib/cassy/cas.rb
+++ b/lib/cassy/cas.rb
@@ -8,7 +8,7 @@ require 'cassy/utils'
 # the Cassy::Controllers module.
 module Cassy
   module CAS
-    
+
     def settings
       Cassy.config
     end
@@ -66,7 +66,7 @@ module Cassy
       https.start do |conn|
         path = uri.path.empty? ? '/' : uri.path
         path += '?' + uri.query unless (uri.query.nil? || uri.query.empty?)
-      
+
         pgt = ProxyGrantingTicket.new
         pgt.ticket = "PGT-" + Cassy::Utils.random_string(60)
         pgt.iou = "PGTIOU-" + Cassy::Utils.random_string(57)
@@ -81,7 +81,7 @@ module Cassy
         response = conn.request_get(path)
         # TODO: follow redirects... 2.5.4 says that redirects MAY be followed
         # NOTE: The following response codes are valid according to the JA-SIG implementation even without following redirects
-      
+
         if %w(200 202 301 302 304).include?(response.code)
           # 3.4 (proxy-granting ticket IOU)
           pgt.save!
@@ -143,7 +143,7 @@ module Cassy
     module_function :clean_service_url
 
     def base_service_url(full_service_url)
-      # strips a url back to the domain part only 
+      # strips a url back to the domain part only
       # so that a service ticket can work for all urls on a given domain
       # eg http://www.something.com/something_else
       # is stripped back to
@@ -154,24 +154,25 @@ module Cassy
       match && match[0]
     end
     module_function :base_service_url
-    
+
     def detect_ticketing_service(service)
       # try to find the service in the valid_services list
       # if loosely_matched_services is true, try to match the base url of the service to one in the valid_services list
       # if still no luck, check if there is a default_redirect_url that we can use
-      @service||= service
-      @ticketing_service||= valid_services.detect{|s| s == @service } || 
+      @service ||= service
+      @ticketing_service||= valid_services.detect{|s| s == @service } ||
         (settings[:loosely_match_services] == true && valid_services.detect{|s| base_service_url(s) == base_service_url(@service)})
       if !@ticketing_service && settings[:default_redirect_url]
         @default_redirect_url||= settings[:default_redirect_url][Rails.env]
-        @ticketing_service = @default_redirect_url
+        # make sure you replace the @service attribute to prevent fishing attacks
+        @service = @ticketing_service = @default_redirect_url
       end
       @username||= params[:username].try(:strip)
       @password||= params[:password]
       @lt||= params['lt']
     end
     module_function :detect_ticketing_service
-    
+
     def cas_login
       if valid_credentials?
         @tgt||= Cassy::TicketGrantingTicket.generate(ticket_username, @extra_attributes, @hostname)
@@ -191,7 +192,7 @@ module Cassy
       end
     end
     module_function :cas_login
-    
+
     # Initializes authenticator, returns true / false depending on if user credentials are accurate
     def valid_credentials?
       detect_ticketing_service(params[:service])
@@ -213,7 +214,7 @@ module Cassy
       return valid
     end
     module_function :valid_credentials?
-    
+
     protected
 
     def ticket_username
@@ -223,7 +224,7 @@ module Cassy
       @cas_client_username = user.send(settings["client_app_user_field"]) if settings["client_app_user_field"].present? && !!user
       @cas_client_username || @username
     end
-    
+
     def ticketed_user(ticket)
       # Find the SSO's instance of the user
       @ticketed_user ||= authenticator.find_user_from_ticket(ticket) unless !ticket


### PR DESCRIPTION
if we don't override @service it'll incorrectly redirect to the provided url that may not be a valid service.