### PR TITLE
Allow auth callbacks to known domains

### DIFF
--- a/spec/default_config.yml
+++ b/spec/default_config.yml
@@ -13,6 +13,9 @@ authenticator:
 
   
 enable_single_sign_out: true
+domain_list:
+  test:
+    - http://my.app.test
 service_list:
   test:
     - http://my.app.test

--- a/spec/default_config.yml
+++ b/spec/default_config.yml
@@ -15,7 +15,7 @@ authenticator:
 enable_single_sign_out: true
 domain_list:
   test:
-    - http://my.app.test
+    - http://app.test
 service_list:
   test:
     - http://my.app.test


### PR DESCRIPTION
By default Cassy allows auth callbacks to a known whitelist of service urls. This is fine for CORE since there's only `app.backupify.com`

However, since we will have multiple lego nodes, we don't want to have to update user_sso's `cassy.yml` every time we standup a new node. 

This change allows whitelisting known domains which will allow us to match any `https://*.backupify.com` server in user_sso.